### PR TITLE
fix: FIREBASE_TOKEN auth

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,9 @@ export default function firebasePlugin({projectId, projectName = projectId, root
       const config = Config.load(options);
       // @ts-ignore
       options.config = config;
-      setActiveAccount(options, account);
+      if (account) {
+        setActiveAccount(options, account);
+      }
       if (materializeConfig) {
         await requireAuth(options);
         await ensureApi(options);


### PR DESCRIPTION
This PR prevents error in `setActiveAccount` when account is not determined on `const account = getProjectDefaultAccount(projectDir);`. If auth is needed and `FIREBASE_TOKEN` is provided as alternative account/auth method, it's gonna pick it up and authenticate correctly inside `requireAuth` which I tested, works well for my case.

I'm also not sure why `options.account` is defined unconditionally, even if it's not determined, but in my current case it's not required and undefined value is ignored later on in firebase-tools internals, so I don't wanna make premature fixes until I know it's really needed. So keep it as is.