### PR TITLE
fix: emulators not shutting down

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-firebase",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-firebase",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "MIT",
       "dependencies": {
         "firebase-tools": "^11.18.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-firebase",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,7 @@ export default function firebasePlugin({projectId, projectName = projectId, root
       if (!process.env.IS_FIREBASE_CLI) {
         process.env.IS_FIREBASE_CLI = 'true';
         setupLoggers();
-        shutdownWhenKilled({});
+        shutdownWhenKilled({}).then(() => process.exit(0));
       }
       if (typeof projectId !== 'string') projectId = projectId(server);
       if (typeof projectName !== 'string') projectName = projectName(server);


### PR DESCRIPTION
process.exit() was previously done in shutdownWhenKilled() but
was removed: https://github.com/firebase/firebase-tools/pull/4851/files\#diff-a1ad4cf0c9fac1cb8905b5f41ced4ca7dab42af061d383305738cc514a7923f3L314
